### PR TITLE
BLD: migrate from PyPDF2 (deprecated) to its replacement pypdf

### DIFF
--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -36,13 +36,6 @@ from amical.tools import compute_pa
 from amical.tools import cov2cor
 
 
-def _PYPDF2_VERSION():
-    from importlib.metadata import version
-    from packaging.version import Version
-
-    return Version(version("PyPDF2"))
-
-
 def _ASTROPY_VERSION():
     from importlib.metadata import version
     from packaging.version import Version
@@ -1063,14 +1056,8 @@ def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix):
 
 
 def produce_result_pdf(figdir, filename):
-    from packaging.version import Version
+    from pypdf import PdfMerger, PdfReader
 
-    if _PYPDF2_VERSION() >= Version("1.28"):
-        from PyPDF2 import PdfMerger
-        from PyPDF2 import PdfReader
-    else:
-        from PyPDF2 import PdfFileMerger as PdfMerger
-        from PyPDF2 import PdfFileReader as PdfReader
     # Call the PdfMerger
     mergedObject = PdfMerger()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    PyPDF2
     astropy
     astroquery
     corner
@@ -33,6 +32,7 @@ install_requires =
     munch
     numpy
     packaging>=21.0
+    pypdf>=3.2.0
     scipy
     tabulate
     termcolor


### PR DESCRIPTION
fix deprecation warnings seen in recent CI jobs
For context: https://pypdf2.readthedocs.io/en/latest/meta/CHANGELOG.html#version-3-1-0-2022-12-23