### PR TITLE
BLD: require astropy>=5.0, drop dependency on packaging

### DIFF
--- a/amical/get_infos_obs.py
+++ b/amical/get_infos_obs.py
@@ -15,7 +15,6 @@ from termcolor import cprint
 
 from amical.tools import mas2rad
 
-
 if sys.version_info >= (3, 9):
     import importlib.resources as importlib_resources
 else:

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -1,13 +1,8 @@
-import astropy
 import munch
 import pytest
 from astropy.io import fits
-from packaging.version import Version
 
 from amical.mf_pipeline.bispect import _add_infos_header
-
-# Astropy versions for
-ASTROPY_VERSION = Version(astropy.__version__)
 
 
 @pytest.fixture()
@@ -57,18 +52,10 @@ def test_add_infos_header_commentary(commentary_infos):
     munch.munchify(commentary_infos)
 
 
-@pytest.mark.xfail(
-    ASTROPY_VERSION < Version("5.0rc"),
-    reason="Munch cannot handle commentary cards for Astropy < 5.0",
-)
 def test_commentary_infos_keep(commentary_infos):
     assert "HISTORY" in commentary_infos.hdr
 
 
-@pytest.mark.skipif(
-    ASTROPY_VERSION < Version("5.0"),
-    reason="Astropy < 5.0 raised a warning for commentary cards",
-)
 def test_no_commentary_warning_astropy_version():
     # Add hdr to infos placeholders for everything but hdr
     mf = munch.Munch(pixelSize=1.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "astropy",
+    "astropy>=5.0",
     "astroquery",
     "corner",
     "emcee",
@@ -30,7 +30,6 @@ dependencies = [
     "matplotlib",
     "munch",
     "numpy",
-    "packaging>=21.0",
     "pypdf>=3.2.0",
     "scipy",
     "tabulate",


### PR DESCRIPTION
Follow up to #45 and #73
