### PR TITLE
BUG: fix implicit conversion from array to scalar (deprecated in numpy 1.25)

### DIFF
--- a/amical/analysis/fitting.py
+++ b/amical/analysis/fitting.py
@@ -142,7 +142,7 @@ def model_standard(obs, param):
             else:
                 mod = np.nan
 
-            res[i] = mod
+            res[i] = np.asarray(mod).item()
         except TypeError:
             pass
 
@@ -490,7 +490,7 @@ def compute_chi2_curve(
     chi2r_m = l_chi2r.min()
     chi2_m = l_chi2.min()
 
-    fitted_param = array_params[l_chi2 == chi2_m]
+    fitted_param = array_params[l_chi2 == chi2_m].item()
 
     c_left = array_params <= fitted_param
     c_right = array_params >= fitted_param

--- a/amical/get_infos_obs.py
+++ b/amical/get_infos_obs.py
@@ -279,7 +279,7 @@ def get_ifu_table(
                 np.arange(len(wl))[i_wl],
                 wl[i_wl],
                 "ro",
-                label="Selected (%2.2f µm)" % wl[i_wl],
+                label="Selected (%2.2f µm)" % wl[i_wl[0]],
             )
         elif multiple_wl:
             plt.plot(


### PR DESCRIPTION
fix #171

validation on my fork at https://github.com/neutrinoceros/AMICAL/actions/runs/4806682041