### PR TITLE
BUG: allow floating point errors at machine precision when comparing result from np.cos with 1.0

### DIFF
--- a/amical/analysis/fitting.py
+++ b/amical/analysis/fitting.py
@@ -55,7 +55,12 @@ def check_params_model(param):
         elong = np.cos(np.deg2rad(param["incl"]))
         majorAxis = mas2rad(param["majorAxis"])
         posang = np.deg2rad(param["posang"])
-        if (elong < 1) or (posang < 0) or (posang > 180) or (majorAxis < 0):
+        if (
+            (elong < 1 and abs(1 - elong) > 4e-16)
+            or (posang < 0)
+            or (posang > np.pi)
+            or (majorAxis < 0)
+        ):
             log = "# elong > 1,\n# minorAxis > 0 mas,\n# 0 < angle < 180 deg.\n"
             isValid = False
 


### PR DESCRIPTION
This resolves a failure seen in today's weekly CI job with upstream dev versions.
The cause of the regression is a change of implementation in numpy.cos which causes new floating point errors for `np.cos(0)` (see https://github.com/numpy/numpy/issues/23773 and https://github.com/numpy/numpy/pull/23399)

Seeing this can probably not be adressed in numpy itself, let's add some margin of error to the check.
I also fixed another bug where an angle in radian (`posang`) was compared to `180`.