### PR TITLE
TST: use nightly builds for numpy matplotlib and scipy

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -38,18 +38,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools wheel
-        python -m pip install git+https://github.com/numpy/numpy.git
-
-        python -m pip install git+https://github.com/matplotlib/matplotlib.git
+        python -m pip install --upgrade --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy matplotlib scipy
         python -m pip install git+https://github.com/astropy/astropy.git
 
         # build-time dependencies for uncertainties + scipy with --no-build-isolation
         python -m pip install pybind11 cython pkgconfig
-
-        # using nighlty wheels for scicy because a release may
-        # result in downgrading numpy, which will cause ABI imcompatibilities at import time
-        # and building scipy from source triples our build time
-        python -m pip install -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
 
     - name: Build amical
       run: |


### PR DESCRIPTION
this should drastically reduce testing build time