### PR TITLE
RFC: avoid deprecated pypdf API

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -51,4 +51,4 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest
+        pytest --color=yes

--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -1019,10 +1019,9 @@ def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix):
 
 
 def produce_result_pdf(figdir, filename):
-    from pypdf import PdfMerger, PdfReader
+    from pypdf import PdfReader, PdfWriter
 
-    # Call the PdfMerger
-    mergedObject = PdfMerger()
+    mergedObject = PdfWriter()
 
     for fileNumber in range(7):
         ifile = os.path.join(figdir, f"{filename}_{fileNumber + 1}.pdf")


### PR DESCRIPTION
getting around a new deprecation warning:
`DeprecationWarning: PdfMerger is deprecated and will be removed in pypdf 5.0.0. Use PdfWriter instead.`
