### PR TITLE
MNT: noop update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@
 
 version: 2
 updates:
+
 - package-ecosystem: pip
   directory: /requirements
   schedule:


### PR DESCRIPTION
tentative fix for #181 following the answer I got from github's support team, which I copy verbatim here:

> Lauren (GitHub Support) Sep 6, 2023, 12:44 PM UTC
Hello Clément,Thank you for contacting GitHub support. It looks like Dependabot didn't pick up your dependabot.yml file, but I don't see any issues with it that would prevent it from processing. Can you try updating the file with something small like a new comment line or reverse the order of the package-ecosystem sections? This should force Dependabot to re-process the file and will hopefully recognize it.Kind regards,Lauren

