### PR TITLE
ENH: add drop-in replacement for tabulate

### DIFF
--- a/amical/_cli/commands/calibrate.py
+++ b/amical/_cli/commands/calibrate.py
@@ -5,10 +5,10 @@ from pathlib import Path
 
 from astroquery.simbad import Simbad
 from matplotlib import pyplot as plt
-from tabulate import tabulate
 from termcolor import cprint
 
 import amical
+from amical._rich_display import tabulate
 
 
 def _query_simbad(targetname):

--- a/amical/_cli/commands/calibrate.py
+++ b/amical/_cli/commands/calibrate.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from astroquery.simbad import Simbad
 from matplotlib import pyplot as plt
-from termcolor import cprint
+from rich import print as rprint
 
 import amical
 from amical._rich_display import tabulate
@@ -106,7 +106,7 @@ def perform_calibrate(args):
     # Position angle from North to East
     pa = bs_t.infos.pa
 
-    cprint("\nPosition angle computed for the data: pa = %2.3f deg" % pa, "cyan")
+    rprint(f"[cyan]\nPosition angle computed for the data: pa = {pa:2.3f} deg")
 
     # Display and save the results as oifits
     if args.plot:

--- a/amical/_cli/commands/clean.py
+++ b/amical/_cli/commands/clean.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 from astropy.io import fits
 from matplotlib import pyplot as plt
-from tabulate import tabulate
 from termcolor import cprint
 from tqdm import tqdm
 
 import amical
+from amical._rich_display import tabulate
 
 
 def _select_data_file(args, process):

--- a/amical/_cli/commands/clean.py
+++ b/amical/_cli/commands/clean.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 from astropy.io import fits
 from matplotlib import pyplot as plt
+from rich.progress import track
 from termcolor import cprint
-from tqdm import tqdm
 
 import amical
 from amical._rich_display import tabulate
@@ -96,7 +96,7 @@ def perform_clean(args):
 
     if args.all:
         # Clean all files in --datadir
-        for f in tqdm(l_file, ncols=100, desc="# files"):
+        for f in track(l_file, description="# files"):
             hdr = fits.open(f)[0].header
             hdr["HIERARCH AMICAL step"] = "CLEANED"
             cube = amical.select_clean_data(f, **clean_param, display=True)

--- a/amical/_cli/commands/clean.py
+++ b/amical/_cli/commands/clean.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 from astropy.io import fits
 from matplotlib import pyplot as plt
+from rich import print as rprint
 from rich.progress import track
-from termcolor import cprint
 
 import amical
 from amical._rich_display import tabulate
@@ -57,7 +57,7 @@ def _select_data_file(args, process):
 
 def perform_clean(args):
     """Clean the data with AMICAL."""
-    cprint("---- AMICAL clean process ----", "cyan")
+    rprint("[cyan]---- AMICAL clean process ----")
 
     clean_param = {
         "isz": args.isz,

--- a/amical/_cli/commands/extract.py
+++ b/amical/_cli/commands/extract.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 from astropy.io import fits
 from matplotlib import pyplot as plt
+from rich import print as rprint
 from rich.progress import track
-from termcolor import cprint
 
 import amical
 from amical._cli.commands.clean import _select_data_file
@@ -29,7 +29,7 @@ def _extract_bs_ifile(f, args, ami_param):
 def perform_extract(args):
     """CLI interface to extract the data with AMICAL (compute bispectrum object
     with all raw observables)."""
-    cprint("---- AMICAL extract started ----", "cyan")
+    rprint("[cyan]---- AMICAL extract started ----")
     t0 = time.time()
     ami_param = {
         "peakmethod": args.peakmethod,
@@ -71,7 +71,7 @@ def perform_extract(args):
         for f in track(l_file, description="# files"):
             _extract_bs_ifile(f, args, ami_param)
     t1 = time.time() - t0
-    cprint("---- AMICAL extract done (%2.1fs) ----" % t1, "cyan")
+    rprint(f"[cyan]---- AMICAL extract done ({t1:2.1f}s) ----")
     if args.plot:
         plt.show(block=True)
     return 0

--- a/amical/_cli/commands/extract.py
+++ b/amical/_cli/commands/extract.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 from astropy.io import fits
 from matplotlib import pyplot as plt
+from rich.progress import track
 from termcolor import cprint
-from tqdm import tqdm
 
 import amical
 from amical._cli.commands.clean import _select_data_file
@@ -68,7 +68,7 @@ def perform_extract(args):
         f = _select_data_file(args, process="extract")[0]
         _extract_bs_ifile(f, args, ami_param)
     else:
-        for f in tqdm(l_file, ncols=100, desc="# files"):
+        for f in track(l_file, description="# files"):
             _extract_bs_ifile(f, args, ami_param)
     t1 = time.time() - t0
     cprint("---- AMICAL extract done (%2.1fs) ----" % t1, "cyan")

--- a/amical/_rich_display.py
+++ b/amical/_rich_display.py
@@ -1,0 +1,9 @@
+from typing import Any, List, Sequence
+
+from astropy.table import Table
+
+
+def tabulate(rows: Sequence[Any], headers: List[str]) -> Table:
+    # a drop-in replacement for tabulate.tabulate
+    data = {name: [row[i] for row in rows] for i, name in enumerate(headers)}
+    return Table(data)

--- a/amical/analysis/easy_candid.py
+++ b/amical/analysis/easy_candid.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Optional, Union
 
 import numpy as np
-from termcolor import cprint
+from rich import print as rprint
 
 from amical.externals import candid
 
@@ -57,7 +57,7 @@ def candid_grid(
     if doNotFit is None:
         doNotFit = ["diam*"]
 
-    cprint(" | --- Start CANDID fitting --- :", "green")
+    rprint("[green] | --- Start CANDID fitting --- :")
     o = candid.Open(
         input_data,
         extra_error=extra_error_cp,
@@ -116,8 +116,10 @@ def candid_grid(
         posang = 360 + posang
 
     cr = 1 / f_u
-    cprint(f"\nResults binary fit (χ2 = {chi2:2.1f}, nσ = {nsigma:2.1f}):", "cyan")
-    cprint("-------------------", "cyan")
+    rprint(
+        f"[cyan]\nResults binary fit (χ2 = {chi2:2.1f}, nσ = {nsigma:2.1f}):\n"
+        "-------------------"
+    )
 
     print(f"Sep = {s.nominal_value:2.1f} +/- {s.std_dev:2.1f} mas")
     print(f"Theta = {posang.nominal_value:2.1f} +/- {posang.std_dev:2.1f} deg")
@@ -164,7 +166,7 @@ def candid_cr_limit(
     if methods is None:
         methods = ["injection"]
 
-    cprint(" | --- Start CANDID contrast limit --- :", "green")
+    rprint("[green] | --- Start CANDID contrast limit --- :")
     o = candid.Open(
         input_data,
         extra_error=extra_error_cp,

--- a/amical/analysis/fitting.py
+++ b/amical/analysis/fitting.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 import numpy as np
-from tqdm import tqdm
+from rich.progress import track
 
 import amical
 from amical.analysis import models
@@ -469,7 +469,7 @@ def compute_chi2_curve(
 
     fitOnly.remove(name_param)
     l_chi2r = []
-    for pr in tqdm(array_params, desc="Chi2 curve (%s)" % name_param, ncols=100):
+    for pr in track(array_params, description=f"Chi2 curve ({name_param}"):
         params[name_param] = pr
         lfits = smartfit(
             obs,

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -14,8 +14,8 @@ import sys
 import warnings
 
 import numpy as np
+from rich.progress import track
 from termcolor import cprint
-from tqdm import tqdm
 
 from amical.tools import apply_windowing, crop_max, find_max
 
@@ -585,7 +585,7 @@ def clean_data(
 
     bad_map, add_bad = _get_3d_bad_pixels(bad_map, add_bad, data)
 
-    for i in tqdm(range(n_im), ncols=100, desc="Cleaning", leave=False):
+    for i in track(range(n_im), description="Cleaning"):
         img0 = data[i]
         img0 = _apply_edge_correction(img0, edge=edge)
         if bad_map is not None:

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -14,8 +14,8 @@ import sys
 import warnings
 
 import numpy as np
+from rich import print as rprint
 from rich.progress import track
-from termcolor import cprint
 
 from amical.tools import apply_windowing, crop_max, find_max
 
@@ -101,10 +101,10 @@ def select_data(cube, clip_fact=0.5, clip=False, verbose=True, display=True):
 
     if verbose:
         if (med_flux / std_flux) <= 5.0:
-            cprint(
-                "\nStd of the fluxes along the cube < 5 (%2.1f):\n -> sigma clipping is suggested (clip=True)."
-                % (med_flux / std_flux),
-                "cyan",
+            rprint(
+                "[cyan]\n"
+                f"Std of the fluxes along the cube < 5 ({med_flux / std_flux:2.1f}):\n"
+                " -> sigma clipping is suggested (clip=True).",
             )
 
     limit_flux = med_flux - clip_fact * std_flux
@@ -186,9 +186,9 @@ def select_data(cube, clip_fact=0.5, clip=False, verbose=True, display=True):
         n_good = len(cube_cleaned_checked)
         n_bad = len(cube) - n_good
         if clip:
-            cprint("\n---- σ-clip + centered fluxes selection ---", "cyan")
+            rprint("[cyan]\n---- σ-clip + centered fluxes selection ---")
         else:
-            cprint("\n---- centered fluxes selection ---", "cyan")
+            rprint("[cyan]\n---- centered fluxes selection ---")
         print(
             "%i/%i (%2.1f%%) are flagged as bad frames"
             % (n_bad, len(cube), 100 * float(n_bad) / len(cube))

--- a/amical/externals/pymask/cpo.py
+++ b/amical/externals/pymask/cpo.py
@@ -2,7 +2,7 @@ import glob
 import logging
 
 import numpy as np
-from termcolor import cprint
+from rich import print as rprint
 
 from . import oifits
 from .cp_tools import project_cps
@@ -132,10 +132,9 @@ class cpo:
         self.t3data = np.array(t3data)
         self.t3err = np.array(t3err)
         if verbose:
-            cprint(
-                r"PYMASK - %i oifits loaded : n=%ix%i=%i closure phases."
-                % (len(lfiles), len(lfiles), nbl, len(t3data)),
-                "green",
+            rprint(
+                rf"[green]PYMASK - {len(lfiles)} oifits loaded : "
+                f"n={len(lfiles)}x{nbl}={len(t3data)} closure phases."
             )
 
 

--- a/amical/get_infos_obs.py
+++ b/amical/get_infos_obs.py
@@ -11,7 +11,7 @@ Instruments and mask informations.
 import sys
 
 import numpy as np
-from termcolor import cprint
+from rich import print as rprint
 
 from amical.tools import mas2rad
 
@@ -169,7 +169,9 @@ def get_mask(ins, mask, first=0):
                 nrand.append(x)
         xycoords_sel = xycoords[nrand]
     except KeyError:
-        cprint(f"\n-- Error: maskname ({mask}) unknown for {ins}.", "red")
+        rprint(
+            f"[red]\n-- Error: maskname ({mask}) unknown for {ins}.", file=sys.stderr
+        )
         xycoords_sel = None
     return xycoords_sel
 

--- a/amical/ifu.py
+++ b/amical/ifu.py
@@ -14,7 +14,7 @@ import warnings
 import numpy as np
 from astropy.io import fits
 from matplotlib import pyplot as plt
-from tqdm import tqdm
+from rich.progress import track
 
 from .data_processing import select_clean_data
 from .get_infos_obs import get_wavelength
@@ -141,8 +141,9 @@ def clean_data(
 
     cube_lambda = np.zeros([nframe, nlambda, isz, isz])
 
-    for i in tqdm(
-        range(len(list_file)), desc="Format/clean IFU (%s)" % (hdr["OBJECT"]), ncols=100
+    for i in track(
+        range(len(list_file)),
+        desription="Format/clean IFU (%s)" % (hdr["OBJECT"]),
     ):
         cube_cleaned = select_clean_data(list_file[i], **clean_param)
         cube_lambda[i] = cube_cleaned

--- a/amical/mf_pipeline/ami_function.py
+++ b/amical/mf_pipeline/ami_function.py
@@ -14,10 +14,11 @@ All AMI related function, the most important are:
 --------------------------------------------------------------------
 """
 import os
+import sys
 from pathlib import Path
 
 import numpy as np
-from termcolor import cprint
+from rich import print as rprint
 
 from amical.dpfit import leastsqFit
 from amical.externals.munch import munchify as dict2class
@@ -369,7 +370,7 @@ def make_mf(
     # ------------------------------------------
     pixelsize = get_pixel_size(instrument)  # Pixel size of the detector [rad]
     if pixelsize is np.nan:
-        cprint("Error: Pixel size unknown for %s." % instrument, "red")
+        rprint(f"[red]Error: Pixel size unknown for {instrument}.", file=sys.stderr)
         return None
     # Wavelength of the filter (filt[0]: central, filt[1]: width)
     filt = get_wavelength(instrument, filtname)
@@ -419,15 +420,12 @@ def make_mf(
 
     ncp_i = int((n_holes - 1) * (n_holes - 2) / 2)
     if verbose:
-        cprint("---------------------------", "cyan")
-        cprint(
-            "%s (%s): %i holes masks" % (instrument.upper(), filtname, n_holes), "cyan"
-        )
-        cprint("---------------------------", "cyan")
-        cprint(
-            "nbl = %i, nbs = %i, ncp_i = %i, ncov = %i"
-            % (n_baselines, n_bispect, ncp_i, index_mask.n_cov),
-            "cyan",
+        rprint(
+            "[cyan]---------------------------\n"
+            f"{instrument.upper()} ({filtname}): {n_holes} holes masks\n"
+            "---------------------------\n"
+            f"nbl = {n_baselines}, nbs = {n_bispect}, "
+            f"ncp_i = {ncp_i}, ncov = {index_mask.n_cov}"
         )
 
     # Consider the filter to be made up of n_wl wavelengths
@@ -480,8 +478,9 @@ def make_mf(
                 hole_diam=hole_diam,
             )
         else:
-            cprint(
-                "Error: choose the extraction method 'gauss', 'fft' or 'square'.", "red"
+            rprint(
+                "[red]Error: choose the extraction method 'gauss', 'fft' or 'square'.",
+                file=sys.stderr,
             )
             return None
 
@@ -795,8 +794,11 @@ def tri_pix(array_size, sampledisk_r, verbose=True, display=True):
     """Compute all combination of triangle for a given splodge size"""
 
     if array_size % 2 == 1:
-        cprint("\n! Warnings: image dimension must be even (%i)" % array_size, "red")
-        cprint("Possible triangle inside the splodge should be incorrect.\n", "red")
+        rprint(
+            f"[red]\n! Warnings: image dimension must be even ({array_size})\n"
+            "Possible triangle inside the splodge should be incorrect.\n",
+            file=sys.stderr,
+        )
 
     d = np.zeros([array_size, array_size])
     d = plot_circle(d, array_size // 2, array_size // 2, sampledisk_r, display=False)

--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -13,12 +13,13 @@ and calc_bispect.pro).
 --------------------------------------------------------------------
 """
 import os
+import sys
 import time
 from pathlib import Path
 
 import numpy as np
+from rich import print as rprint
 from rich.progress import track
-from termcolor import cprint
 
 from amical.externals.munch import munchify as dict2class
 from amical.get_infos_obs import get_mask
@@ -360,23 +361,25 @@ def _check_input_infos(hdr, targetname=None, filtname=None, instrum=None, verbos
         if targetname is not None:
             target = targetname
             if verbose:
-                cprint(
-                    "Warning: OBJECT is not in the header, targetname is used (%s)."
-                    % targetname,
-                    "green",
+                rprint(
+                    f"[green]Warning: OBJECT is not in the header, targetname is used ({targetname}).",
+                    file=sys.stderr,
                 )
         else:
-            cprint("Warning: target name not found (header or as input).", "green")
+            rprint(
+                "[green]Warning: target name not found (header or as input).",
+                file=sys.stderr,
+            )
 
     # Check the filter used
     if filt is None:
         if filtname is not None:
             filt = filtname
             if verbose:
-                cprint(
-                    "Warning: FILTER is not in the header, filtname is used (%s)."
-                    % filtname,
-                    "green",
+                rprint(
+                    "[green]Warning: FILTER is not in the header, "
+                    f"filtname is used ({filtname}).",
+                    file=sys.stderr,
                 )
 
     # Check the instrument used
@@ -425,12 +428,18 @@ def _set_good_nblocks(n_blocks, n_ps, verbose=False):
     """
     if (n_blocks == 0) or (n_blocks == 1):
         if verbose:
-            cprint("! Warning: nblocks == 0 -> n_blocks set to n_ps", "green")
+            rprint(
+                "[green]! Warning: nblocks == 0 -> n_blocks set to n_ps",
+                file=sys.stderr,
+            )
         n_blocks = n_ps
     elif n_blocks > n_ps:
         if verbose:
-            cprint("------------------------------------", "green")
-            cprint("! Warning: nblocks > n_ps -> n_blocks set to n_ps", "green")
+            rprint(
+                "[green]------------------------------------\n"
+                "! Warning: nblocks > n_ps -> n_blocks set to n_ps",
+                file=sys.stderr,
+            )
         n_blocks = n_ps
     return n_blocks
 
@@ -891,8 +900,7 @@ def _compute_phs_piston(
         find_piston = np.dot(res.x, fitmat)
     else:
         if verbose:
-            cprint("Error calculating hole pistons...", "red")
-            pass
+            rprint("[red]Error calculating hole pistons...", file=sys.stderr)
 
     if display:
         import matplotlib.pyplot as plt
@@ -1118,7 +1126,7 @@ def extract_bs(
     from astropy.io import fits
 
     if verbose:
-        cprint("\n-- Starting extraction of observables --", "cyan")
+        rprint("[cyan]\n-- Starting extraction of observables --")
     start_time = time.time()
 
     if save_to is not None:
@@ -1364,5 +1372,5 @@ def extract_bs(
         produce_result_pdf(save_to, Path(filename).stem)
 
     if verbose:
-        cprint("\nDone (exec time: %d min %2.1f s)." % (m, t - m * 60), color="magenta")
+        rprint("[magenta]\nDone (exec time: %d min %2.1f s)." % (m, t - m * 60))
     return dict2class(obs_result)

--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -13,13 +13,12 @@ and calc_bispect.pro).
 --------------------------------------------------------------------
 """
 import os
-import sys
 import time
 from pathlib import Path
 
 import numpy as np
+from rich.progress import track
 from termcolor import cprint
-from tqdm import tqdm
 
 from amical.externals.munch import munchify as dict2class
 from amical.get_infos_obs import get_mask
@@ -105,13 +104,10 @@ def _compute_complex_bs(
 
     fluxes = np.zeros(n_ps)
 
-    for i in tqdm(
+    for i in track(
         range(n_ps),
-        ncols=100,
-        desc="Extracting in the cube",
-        leave=False,
-        file=sys.stdout,
-        disable=np.invert(verbose),
+        description="Extracting in the cube",
+        disable=not verbose,
     ):
         ft_frame = ft_arr[i]
         ps = np.abs(ft_frame) ** 2
@@ -649,9 +645,7 @@ def _compute_cp_cov(bs_arr, bs, index_mask, disable=False):
     n_bispect = index_mask.n_bispect
 
     cp_cov = dblarr(n_bispect, n_bispect)
-    for i in tqdm(
-        range(n_bispect), desc="CP covariance", ncols=100, leave=False, disable=disable
-    ):
+    for i in track(range(n_bispect), description="CP covariance", disable=disable):
         for j in range(n_bispect):
             temp1 = (bs_arr[:, i] - bs[i]) * np.conj(bs[i])
             temp2 = (bs_arr[:, j] - bs[j]) * np.conj(bs[j])

--- a/amical/mf_pipeline/idl_function.py
+++ b/amical/mf_pipeline/idl_function.py
@@ -11,8 +11,10 @@ All required IDL function translated into python.
 
 --------------------------------------------------------------------
 """
+import sys
+
 import numpy as np
-from termcolor import cprint
+from rich import print as rprint
 
 from amical.externals.munch import munchify as dict2class
 
@@ -26,7 +28,7 @@ def regress_noc(x, y, weights):
     npts = sy[0]  # # OF OBSERVATIONS
 
     if (len(weights) != sy[0]) or (len(sx) != 2) or (sy[0] != sx[1]):
-        cprint("Incompatible arrays to compute slope error.", "red")
+        rprint("[red]Incompatible arrays to compute slope error.", file=sys.stderr)
 
     xwy = np.dot(x, (weights * y))
     wx = np.zeros([npts, nterm])

--- a/amical/oifits.py
+++ b/amical/oifits.py
@@ -11,9 +11,10 @@ OIFITS related function.
 """
 import datetime
 import os
+import sys
 
 import numpy as np
-from termcolor import cprint
+from rich import print as rprint
 
 from amical.externals.munch import munchify as dict2class
 from amical.tools import rad2mas
@@ -205,8 +206,9 @@ def cal2dict(
         maskname = res_t.infos.maskname
         pixscale = res_t.infos.pixscale
     except KeyError:
-        cprint(
-            "Error: 'INSTRUME', 'NRMNAME' or 'PIXELSCL' are not in the header.", "red"
+        rprint(
+            "[red]Error: 'INSTRUME', 'NRMNAME' or 'PIXELSCL' are not in the header.",
+            file=sys.stderr,
         )
         return None
 
@@ -241,7 +243,7 @@ def cal2dict(
         calib_name = res_c.infos.target
 
     if ind_hole is not None:
-        cprint("Select only independant CP using common hole #%i." % ind_hole, "green")
+        rprint(f"[green]Select only independant CP using common hole #{ind_hole}.")
         sel_ind_cp = _peak1hole_cp(cal.raw_t, ind_hole)
     else:
         sel_ind_cp = np.arange(len(cal.cp))
@@ -521,7 +523,7 @@ def save(
     from astroquery.simbad import Simbad
 
     if observables is None:
-        cprint("\nError save : Wrong data format!", on_color="on_red")
+        rprint("[on red]\nError save : Wrong data format!", file=sys.stderr)
         return None
 
     if oifits_file is None:
@@ -546,7 +548,7 @@ def save(
                     " they should be saved to a pickle file. Use raw=True to turn this"
                     " warning off."
                 )
-                cprint(f"Warning: {msg}", "green")
+                rprint(f"[green]Warning: {msg}", file=sys.stderr)
             iobs = wrap_raw(iobs)
         idic = cal2dict(
             iobs,
@@ -905,7 +907,7 @@ def save(
     savedfile = os.path.join(datadir, oifits_file)
     hdulist.writeto(savedfile, overwrite=True)
     if verbose:
-        cprint("\n\n### OIFITS CREATED (%s)." % oifits_file, "cyan")
+        rprint(f"[cyan]\n\n### OIFITS CREATED ({oifits_file}).", "cyan")
 
     if len(l_dic) == 1:
         l_dic = l_dic[0]

--- a/amical/tests/test_io.py
+++ b/amical/tests/test_io.py
@@ -303,7 +303,7 @@ def test_quiet_mode(global_datadir, capsys):
     bs_keys = list(bs.keys())
     assert isinstance(bs, Munch)
     assert len(bs_keys) == 13
-    assert captured.out == ""
+    assert captured.out.strip() == ""
     assert captured.err == ""
 
 

--- a/amical/tests/test_rich_display.py
+++ b/amical/tests/test_rich_display.py
@@ -1,0 +1,18 @@
+from textwrap import dedent
+
+from amical._rich_display import tabulate
+
+
+def test_tabulate():
+    data = [["1", 2, 34], ["5", 6, 78]]
+    headers = ["name", "id", "adress"]
+    table = tabulate(data, headers)
+    expected = dedent(
+        """
+        name  id adress
+        ---- --- ------
+           1   2     34
+           5   6     78
+        """
+    ).strip()
+    assert str(table) == expected

--- a/amical/tools.py
+++ b/amical/tools.py
@@ -10,10 +10,11 @@ General tools.
 --------------------------------------------------------------------
 """
 import math as m
+import sys
 import warnings
 
 import numpy as np
-from termcolor import cprint
+from rich import print as rprint
 
 from amical.externals.munch import munchify as dict2class
 
@@ -382,10 +383,10 @@ def compute_pa(hdr, n_ps, verbose=False, display=False, *, sci_hdr=None):
         except KeyError:
             nframe = n_ps
         if verbose:
-            cprint(
-                "Warning: %s not in known pa computation -> set to zero.\n"
-                % instrument,
-                "green",
+            rprint(
+                f"[green]Warning: {instrument} not in known pa computation"
+                " -> set to zero.\n",
+                file=sys.stderr,
             )
         pa_exist = False
         l_pa = np.zeros(nframe)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "numpy",
     "pypdf>=3.2.0",
     "scipy",
-    "tabulate",
     "termcolor",
     "tqdm",
     "uncertainties",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,9 @@ dependencies = [
     "matplotlib",
     "numpy",
     "pypdf>=3.2.0",
+    "rich>=13.5.2",
     "scipy",
     "termcolor",
-    "tqdm",
     "uncertainties",
     "importlib_resources>=1.3; python_version < '3.9'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "pypdf>=3.2.0",
     "rich>=13.5.2",
     "scipy",
-    "termcolor",
     "uncertainties",
     "importlib_resources>=1.3; python_version < '3.9'",
 ]


### PR DESCRIPTION
Reduce the number of dependencies: drop dependency on `tabulate` (replaced by astropy.table.Table), `termcolor` and `tqdm` (both replaced by `rich`)

close #182 