### PR TITLE
BUG: fix calling `select_clean_data` with default `isz`

### DIFF
--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -418,7 +418,7 @@ def show_clean_params(
         img1 = img0.copy()
 
     if isz is None:
-        pos = (img1.shape[0]//2, img1.shape[1]//2)
+        pos = (img1.shape[0] // 2, img1.shape[1] // 2)
 
         print(
             "Warning: isz not found (None by default). "

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -356,7 +356,7 @@ def _get_3d_bad_pixels(bad_map, add_bad, data):
 
 def show_clean_params(
     filename,
-    isz,
+    isz=None,
     r1=None,
     dr=None,
     bad_map=None,
@@ -380,7 +380,7 @@ def show_clean_params(
     -----------
 
     `filename` {str}: filename containing the datacube,\n
-    `isz` {int}: Size of the cropped image (default: 256)\n
+    `isz` {int}: Size of the cropped image (default: None)\n
     `r1` {int}: Radius of the rings to compute background sky (default: 100)\n
     `dr` {int}: Outer radius to compute sky (default: 10)\n
     `bad_map` {array}: Bad pixel map with 0 and 1 where 1 set for a bad pixel (default: None),\n
@@ -403,14 +403,6 @@ def show_clean_params(
     img0 = data[nframe]
     dims = img0.shape
 
-    if isz is None:
-        print(
-            "Warning: isz not found (None by default). isz is set to the original image size (%i)"
-            % (dims[0]),
-            file=sys.stderr,
-        )
-        isz = dims[0]
-
     bad_map, add_bad = _get_3d_bad_pixels(bad_map, add_bad, data)
     bmap0 = bad_map[nframe]
     ab0 = add_bad[nframe]
@@ -424,8 +416,22 @@ def show_clean_params(
         img1 = fix_bad_pixels(img0, bmap0, add_bad=ab0)
     else:
         img1 = img0.copy()
-    cropped_infos = crop_max(img1, isz, offx=offx, offy=offy, f=f_kernel)
-    pos = cropped_infos[1]
+
+    if isz is None:
+        pos = (img1.shape[0]//2, img1.shape[1]//2)
+
+        print(
+            "Warning: isz not found (None by default). "
+            f"isz is set to the original image size ({dims[0]}).",
+            file=sys.stderr,
+        )
+
+        isz = dims[0]
+
+    else:
+        # Get expected center for sky correction
+        filtmed = f_kernel is not None
+        _, pos = crop_max(img1, isz, offx=offx, offy=offy, filtmed=filtmed, f=f_kernel)
 
     noBadPixel = False
     bad_pix_x, bad_pix_y = [], []
@@ -653,7 +659,7 @@ def clean_data(
 
 def select_clean_data(
     filename,
-    isz=256,
+    isz=None,
     r1=None,
     dr=None,
     edge=0,
@@ -683,7 +689,7 @@ def select_clean_data(
     -----------
 
     `filename` {str}: filename containing the datacube,\n
-    `isz` {int}: Size of the cropped image (default: {256})\n
+    `isz` {int}: Size of the cropped image (default: {None})\n
     `r1` {int}: Radius of the rings to compute background sky (default: {100})\n
     `dr` {int}: Outer radius to compute sky (default: {10})\n
     `edge` {int}: Patch the edges of the image (VLT/SPHERE artifact, default: {0}),\n

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -625,12 +625,14 @@ def test_isz_none(global_datadir):
     fig = amical.show_clean_params(fits_file, **clean_param)
 
     assert isinstance(fig, plt.Figure)
-    assert fig.axes[0]._viewLim._points[0, 0] == 0.0
-    assert fig.axes[0]._viewLim._points[0, 1] == 0.0
-    assert fig.axes[0]._viewLim._points[1, 0] == 80.0
-    assert fig.axes[0]._viewLim._points[1, 1] == 80.0
+    assert fig.axes[0].get_xlim() == (0.0, 80.0)
+    assert fig.axes[0].get_ylim() == (0.0, 80.0)
 
-    cube_clean = amical.select_clean_data(fits_file, **clean_param)
+    # Set clip=False such that the shape does not changes 
+    cube_clean = amical.select_clean_data(fits_file, clip=False, **clean_param)
+
+    # Get the shape of the array with input images
+    fits_images = fits.getdata(fits_file)
 
     assert isinstance(cube_clean, np.ndarray)
-    assert cube_clean.shape == (217, 81, 81)
+    assert cube_clean.shape == fits_images.shape

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -607,3 +607,30 @@ def test_clean_crop_order():
     img_correct_crop = crop_max(correct, isz, filtmed=False)[0]
 
     assert np.all(np.abs(img_correct_crop - img_cube_clean) < 10 * np.finfo(float).eps)
+
+
+@pytest.mark.usefixtures("close_figures")
+def test_isz_none(global_datadir):
+    fits_file = global_datadir / "test.fits"
+
+    clean_param = {
+        "isz": None,
+        "r1": 35,
+        "dr": 2,
+        "apod": True,
+        "window": 65,
+        "f_kernel": 3,
+    }
+
+    fig = amical.show_clean_params(fits_file, **clean_param)
+
+    assert isinstance(fig, plt.Figure)
+    assert fig.axes[0]._viewLim._points[0, 0] == 0.0
+    assert fig.axes[0]._viewLim._points[0, 1] == 0.0
+    assert fig.axes[0]._viewLim._points[1, 0] == 80.0
+    assert fig.axes[0]._viewLim._points[1, 1] == 80.0
+
+    cube_clean = amical.select_clean_data(fits_file, **clean_param)
+
+    assert isinstance(cube_clean, np.ndarray)
+    assert cube_clean.shape == (217, 81, 81)

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -628,7 +628,7 @@ def test_isz_none(global_datadir):
     assert fig.axes[0].get_xlim() == (0.0, 80.0)
     assert fig.axes[0].get_ylim() == (0.0, 80.0)
 
-    # Set clip=False such that the shape does not changes 
+    # Set clip=False such that the shape does not changes
     cube_clean = amical.select_clean_data(fits_file, clip=False, **clean_param)
 
     # Get the shape of the array with input images


### PR DESCRIPTION
This PR implements a bit more consistent use of the `isz` parameter when the argument is set to `None`.

Currently, the value could be set to `None` in `select_clean_data`, in which case the original image size is used without searching for a new image center.

The `show_clean_params` did however still search for a new image center with `isz=None`. I have changed the way this is implemented, so the original image center is used in that case.

I have also added/changed the default value of `isz` in `show_clean_params` and `select_clean_data` to `None`. Before, the default value of `isz` was only set to `None` in `clean_data`.