### PR TITLE
TST: test against pytest pre-releases

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Build amical
       run: |
-        python -m pip install --requirement requirements/tests.txt
+        python -m pip install --requirement requirements/tests.txt --pre
         python -m pip install --no-build-isolation .
 
     - name: Run tests


### PR DESCRIPTION
I noticed that pytest 8.0.0rc1 breaks AMICAL's tests. I'll be working on fixing this here.