### PR TITLE
MNT: migrate ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,7 @@ amical = [
     "py.typed",
 ]
 
-[tool.ruff]
-target-version = "py38" # https://github.com/charliermarsh/ruff/issues/2039
+[tool.ruff.lint]
 exclude = ["*__init__.py", "amical/externals/*"]
 ignore = ["E501"]
 select = [
@@ -83,7 +82,7 @@ select = [
     "UP",  # pyupgrade
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 combine-as-imports = true
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This follows two changes in ruff's configuration:
- ruff now properly detects our minimum supported Python version so it doesn't need an extra option
- most rules have been moved to a `ruff.lint` section to clarify the distinction with `ruff.format` 