### PR TITLE
DEP: add missing dependency lower bounds and test them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
         python-version:
         - '3.10'
         - '3.13'
+        include:
+        - os: ubuntu-22.04
+          python-version: 3.10.0
+          sync-args: --resolution=lowest-direct
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -33,7 +37,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Build
-      run: uv sync --no-editable --group test
+      run: uv sync --no-editable --group test ${{ matrix.sync-args }}
     - name: Run tests
       run: uv run --no-sync pytest --color=yes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,16 +23,16 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "astropy>=5.0",
-    "astroquery",
-    "corner",
-    "emcee",
-    "h5py",
-    "matplotlib",
-    "numpy",
+    "astroquery>=0.4.4",
+    "corner>=2.2.1",
+    "emcee>=3.1.1",
+    "h5py>=3.6.0",
+    "matplotlib>=3.5.0",
+    "numpy>=1.21.2",
     "pypdf>=3.2.0",
     "rich>=13.5.2",
-    "scipy",
-    "uncertainties",
+    "scipy>=1.7.2",
+    "uncertainties>=3.1.6",
 ]
 
 [project.readme]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "astropy>=5.0",
+    "astropy>=5.0.1",
     "astroquery>=0.4.4",
     "corner>=2.2.1",
     "emcee>=3.1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -36,16 +36,16 @@ typecheck = [
 [package.metadata]
 requires-dist = [
     { name = "astropy", specifier = ">=5.0" },
-    { name = "astroquery" },
-    { name = "corner" },
-    { name = "emcee" },
-    { name = "h5py" },
-    { name = "matplotlib" },
-    { name = "numpy" },
+    { name = "astroquery", specifier = ">=0.4.4" },
+    { name = "corner", specifier = ">=2.2.1" },
+    { name = "emcee", specifier = ">=3.1.1" },
+    { name = "h5py", specifier = ">=3.6.0" },
+    { name = "matplotlib", specifier = ">=3.5.0" },
+    { name = "numpy", specifier = ">=1.21.2" },
     { name = "pypdf", specifier = ">=3.2.0" },
     { name = "rich", specifier = ">=13.5.2" },
-    { name = "scipy" },
-    { name = "uncertainties" },
+    { name = "scipy", specifier = ">=1.7.2" },
+    { name = "uncertainties", specifier = ">=3.1.6" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -35,7 +35,7 @@ typecheck = [
 
 [package.metadata]
 requires-dist = [
-    { name = "astropy", specifier = ">=5.0" },
+    { name = "astropy", specifier = ">=5.0.1" },
     { name = "astroquery", specifier = ">=0.4.4" },
     { name = "corner", specifier = ">=2.2.1" },
     { name = "emcee", specifier = ">=3.1.1" },


### PR DESCRIPTION
I bootstrapped lower bounds with the following strategy:
- if the dependency has extension modules, take the oldest version that has cp310 wheels
- otherwise, take a guess and try a version that was released around the same time as astropy 5.0 (nov 2021)