### PR TITLE
TST: explicitly upgrade lock file as a separate step in bleeding edge CI

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -37,6 +37,9 @@ jobs:
         echo "UV_INDEX=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/astropy/simple/ https://pypi.anaconda.org/liberfa/simple" >> $GITHUB_ENV
         echo "UV_INDEX_STRATEGY=unsafe-best-match" >> $GITHUB_ENV
 
+    - name: upgrade lockfile
+      run: uv lock --upgrade
+
     - name: Build amical
       run: uv sync --no-editable --group test
 


### PR DESCRIPTION
Tentatively address an issue [seen in CI](https://github.com/SAIL-Labs/AMICAL/actions/runs/16460852286/job/46527651401) where nightly builds of at least numpy and matplotlib are apparently ignored. This manifests as a deprecation warning in pillow, triggered by matplotlib, and that I already fixed upstream a couple weeks ago.